### PR TITLE
Emit error when lintspaces fails. Clean-up for watch tasks.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,7 +6,7 @@ var
 	clean = require('gulp-clean'),
 	jshint = require('gulp-jshint'),
 	jscs = require('gulp-jscs'),
-	map = require('gulp-jshint/node_modules/map-stream'),
+	map = require('map-stream'),
 	jshintErrors = []
 ;
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var
-	es 			= require('event-stream'),
-	Lintspaces 	= require('lintspaces'),
+	es          = require('event-stream'),
+	Lintspaces  = require('lintspaces'),
+	PluginError = require('gulp-util').PluginError,
 	colors      = require('gulp-util').colors
 ;
 
@@ -14,6 +15,9 @@ module.exports = function(options) {
 
 		lintspaces.validate(file.path);
 		file.lintspaces = lintspaces.getInvalidLines(file.path);
+
+		// HACK: Clean-up the cache for re-validation
+		delete lintspaces._invalid[file.path];
 
 		return this.emit('data', file);
 	});
@@ -37,6 +41,10 @@ module.exports.reporter = function() {
 					);
 				});
 			}
+		}
+
+		if (Object.keys(file.lintspaces).length) {
+			this.emit('error', new PluginError("lint-spaces", "Failed linting spaces"));
 		}
 
 		return this.emit('data', file);

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "should": "^3.2.0",
+    "map-stream": "^0.1.0",
     "mocha": "^1.18.2",
     "gulp-mocha": "^0.4.1",
     "gulp-jscs": "^0.4.0",


### PR DESCRIPTION
I apologize for the lack of unit tests. I essentially had two problems when using this library and these changes scratched my itch.

- Using `gulp-lintspaces` in a watch would fail. If a file contained a whitespace error once, it would never be removed and be reported again on each change.
- The default reporter did not emit an error when lintspaces existed, making it difficult to exit with a non-zero exit code (used by CI to determine build success)